### PR TITLE
Fix so "-v-" is not incorrectly parsed as "-v" and "--",

### DIFF
--- a/getopt.go
+++ b/getopt.go
@@ -123,7 +123,7 @@ func (optionsDefinition Options) parseCommandLineImpl(args []string, environment
 						currentOption, _ := optionsDefinition.FindOption(opt)
 						key := currentOption.Key()
 
-						options[key], err = assignValue(currentOption.DefaultValue, "true")
+						options[key], err = assignValue(true, "true")
 
 						// make it look as if we have a normal option with a '-' prefix
 						buffer = "-" + buffer[2:]

--- a/getopt.go
+++ b/getopt.go
@@ -134,6 +134,11 @@ func (optionsDefinition Options) parseCommandLineImpl(args []string, environment
 					opt, val, found = parseLongOpt(token)
 				}
 
+				if !found {
+					err = &GetOptError{InvalidOption, "invalid option '" + token + "'"}
+					break
+				}
+
 				currentOption, found := optionsDefinition.FindOption(opt)
 				key := currentOption.Key()
 

--- a/getopt_test.go
+++ b/getopt_test.go
@@ -38,6 +38,49 @@ func TestShortOptionsFlagsParsing(t *testing.T) {
 
 }
 
+func TestLongOptionsFlagsParsing(t *testing.T) {
+	options := Options{
+		"",
+		Definitions{
+			{"verbose|v", "verbose mode", Flag, ""},
+			{"debug", "very very verbose mode", Flag, ""},
+		},
+	}
+
+	os.Args = []string{"prog", "--verbose"}
+	if opts, _, _, e := options.ParseCommandLine(); e == nil {
+		if opts["verbose"].Bool != true {
+			t.Errorf("verbose flag was not set for --verbose")
+		}
+		if opts["debug"].Bool != false {
+			t.Errorf("debug flag was set for --verbose")
+		}
+	} else {
+		t.Errorf("error was set for --verbose")
+	}
+
+	os.Args = []string{"prog", "--error"}
+	if _, _, _, e := options.ParseCommandLine(); e == nil {
+		t.Errorf("error was not set for --error")
+	}
+
+	os.Args = []string{"prog", "-v-"} // bug?
+	if opts, _, _, e := options.ParseCommandLine(); e == nil {
+		t.Errorf("error was not set for -v-")
+		if opts["verbose"].Bool != true {
+			t.Errorf("verbose flag was not set for -v-")
+		}
+		if opts["debug"].Bool != false {
+			t.Errorf("debug flag was set for -v-")
+		}
+	}
+
+	os.Args = []string{"prog", "-v-debug"} // bug?
+	if _, _, _, e := options.ParseCommandLine(); e == nil {
+		t.Errorf("error was not set for -v-debug")
+	}
+}
+
 func TestShortOptionRequiredParsing(t *testing.T) {
 	options := Options{"", Definitions{{"method|m|MON_METHOD", "method: one of either 'heartbeat' or 'nagios'", Required, ""}}}
 

--- a/options.go
+++ b/options.go
@@ -102,7 +102,7 @@ func checkOptionsDefinitionConsistency(optionsDefinition Options) (err *GetOptEr
 
 func (options Options) FindOption(optionString string) (option Option, found bool) {
 	for _, cur := range options.Definitions {
-		if cur.ShortOpt() == optionString || cur.LongOpt() == optionString {
+		if (cur.HasShortOpt() && cur.ShortOpt() == optionString) || (cur.HasLongOpt() && cur.LongOpt() == optionString) {
 			option = cur
 			found = true
 			break


### PR DESCRIPTION
.. where "--" is the first option without short options.

See test case: "-v-" would incorrectly turn into "-v" and "--" where "" (non-found `opt`) would be parsed as the first option that had no short-option letter.

I fixed it in two places. One fix would've been enough, but there is no reason not to check `found` after potentially setting it to false.